### PR TITLE
Revert "Bump rack from 2.0.7 to 2.0.8"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     popper_js (1.14.5)
     public_suffix (4.0.1)
     puma (3.12.2)
-    rack (2.0.8)
+    rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)


### PR DESCRIPTION
Reverts KATO-Hiro/AtCoderQAHub#430